### PR TITLE
fuse package explicit install

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,10 +2,14 @@
 
 # install more packages
 apt-get -y update \
-    && apt-get -y install attr psmisc glusterfs-server
+    && apt-get -y install attr psmisc glusterfs-server fuse
 
 # Clean up
 apt-get -y autoremove \
     && apt-get -y autoclean \
     && apt-get -y clean \
     && rm -fr /tmp/* /var/tmp/* /var/lib/apt/lists/*
+
+# Fix script permissions
+chmod 770 /entrypoint.sh
+chmod 770 /healthcheck.sh


### PR DESCRIPTION
It appears recent versions don't include the necessary package fuse for fusermount. I also ran into script permission issues when attempting to update this and added 2 chmod commands to fix that.